### PR TITLE
DOM_Query::get() no longer treats `0` index as `false'.

### DIFF
--- a/src/PowerTools/DOM/Query.php
+++ b/src/PowerTools/DOM/Query.php
@@ -573,7 +573,7 @@ class DOM_Query {
 
     public function get($index = false) {
         // http://api.jquery.com/get/
-        if ($index) {
+        if (is_int($index)) {
             if ($index < 0) {
                 return $this->nodes[count($this->nodes) + $index];
             }

--- a/src/PowerTools/DOM/Query.php
+++ b/src/PowerTools/DOM/Query.php
@@ -342,6 +342,23 @@ class DOM_Query {
         return $this;
     }
 
+    public function hasClass($class) {
+        // http://api.jquery.com/hasClass/
+
+        $classFound = false;
+
+        $this->each(function($i, $element) use ($class, &$classFound) {
+            if (in_array(
+                    $class,
+                    explode(' ', $element->attr('class'))
+            )) {
+                $classFound = true;
+            }
+        });
+
+        return $classFound;
+    }
+
     public function removeAttr($key) {
         // http://api.jquery.com/removeAttr/
         $keys = explode(' ', $key);

--- a/vendor/PowerTools/DOM/Query.php
+++ b/vendor/PowerTools/DOM/Query.php
@@ -573,7 +573,7 @@ class DOM_Query {
 
     public function get($index = false) {
         // http://api.jquery.com/get/
-        if ($index) {
+        if (is_int($index)) {
             if ($index < 0) {
                 return $this->nodes[count($this->nodes) + $index];
             }

--- a/vendor/PowerTools/DOM/Query.php
+++ b/vendor/PowerTools/DOM/Query.php
@@ -342,6 +342,23 @@ class DOM_Query {
         return $this;
     }
 
+    public function hasClass($class) {
+        // http://api.jquery.com/hasClass/
+
+        $classFound = false;
+
+        $this->each(function($i, $element) use ($class, &$classFound) {
+            if (in_array(
+                    $class,
+                    explode(' ', $element->attr('class'))
+            )) {
+                $classFound = true;
+            }
+        });
+
+        return $classFound;
+    }
+
     public function removeAttr($key) {
         // http://api.jquery.com/removeAttr/
         $keys = explode(' ', $key);


### PR DESCRIPTION
Hi there. I've been using this for a bit and it generally works quite well overall. I had some odd bugs where `DOM_Query::get()` was returning a node list instead of a specific node if the index passed was `0`, and I tracked it down to the overly broad if statement in Query.php, line 593:
```php
if ($index) {
```
This should be:
```php
if (is_int($index)) {
```
...or some other check that accounts for `0`.