### PR TITLE
 DOM_Query::select() now checks for element before wrapping. 

### DIFF
--- a/src/PowerTools/DOM/Query.php
+++ b/src/PowerTools/DOM/Query.php
@@ -596,8 +596,16 @@ class DOM_Query {
             case 'DOM_Query':
                 $wrapper->nodes = $this->_importNodes($selector);
                 break;
-            default:
+            case 'DOMElement':
                 $wrapper->nodes = array($selector);
+                break;
+            default:
+                // Don't assume we've been passed an element node, as that can
+                // result in hard to pin down errors with _runGetter, for
+                // example, where it may be passed a null value as the first
+                // argument, and also have a single null value in the nodes
+                // array, which causes a fatal error.
+                $wrapper->nodes = array();
         }
         return $wrapper;
     }

--- a/vendor/PowerTools/DOM/Query.php
+++ b/vendor/PowerTools/DOM/Query.php
@@ -596,8 +596,16 @@ class DOM_Query {
             case 'DOM_Query':
                 $wrapper->nodes = $this->_importNodes($selector);
                 break;
-            default:
+            case 'DOMElement':
                 $wrapper->nodes = array($selector);
+                break;
+            default:
+                // Don't assume we've been passed an element node, as that can
+                // result in hard to pin down errors with _runGetter, for
+                // example, where it may be passed a null value as the first
+                // argument, and also have a single null value in the nodes
+                // array, which causes a fatal error.
+                $wrapper->nodes = array();
         }
         return $wrapper;
     }


### PR DESCRIPTION
I'm not sure if this might have unintended side effects, since I'm guessing at what the code in DOM_Query::select() is doing in the default case - which I assume is when a DOMNode is passed? In my own code this doesn't seem to cause any problems, but you'd know your code better than I.